### PR TITLE
【insert_event.py】同じ予定が複数カレンダーに登録されるバグを修正

### DIFF
--- a/insert_event.py
+++ b/insert_event.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
-import datetime
-import pickle
-import os, os.path
 import sys
-import urllib.parse as urlparse
+import copy
+import pickle
+import datetime
+import os, os.path
 import requests, re, bs4
+import urllib.parse as urlparse
 from datetime import datetime as dt
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -55,13 +56,13 @@ def get_atcoder_schedule() :
         duration_timedelta = datetime.timedelta(hours=int(duration_time[0]), minutes=int(duration_time[1]))
         end_datetime = start_datetime + duration_timedelta
         tmp_event['end']['dateTime'] = end_datetime.strftime('%Y-%m-%dT%H:%M:%S')
-        event_list.append(tmp_event)
+        event_list.append(copy.deepcopy(tmp_event))
     return event_list
 
 
 def main():
     event_list = get_atcoder_schedule()
-    
+
     # 既にカレンダーに追加しているコンテスト名を読みこむ
     scheduled = []
     with open('data/schedule.txt', mode='rt') as f:


### PR DESCRIPTION
**問題の原因**
event_list に append する際にいわゆる「浅いコピー」の影響により，リスト内に append 済みの要素の値が意図せず変更されていた．

**問題の解決方法**
「深いコピー」を使用することで修正した．

**参考**
https://www.headboost.jp/python-copy-deepcopy/

Fixes #3 