### PR TITLE
URLの表示位置を変更、データ構造とデータの更新方法を変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import datetime
+from dateutil import parser
 import requests, bs4
 import urllib.parse as urlparse
 from datetime import datetime as dt
@@ -35,24 +36,29 @@ class TimeWithStrTimeZone:
 @dataclass
 class CalendarEvent:
     summary: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
     start_at: InitVar[datetime.datetime]
     end_at: InitVar[datetime.datetime]
     start: TimeWithStrTimeZone = field(init=False)
     end: TimeWithStrTimeZone = field(init=False)
-    location: str = ''
-    description: str = ''
+    id: str = ''
+    url: str = ''
 
     def __post_init__(self, start_at, end_at):
         self.start = TimeWithStrTimeZone(start_at)
         self.end = TimeWithStrTimeZone(end_at)
+    
+    def get_description(self) -> str:
+        return f"created at: {utc_to_jst_str(self.created_at)}\nupdated at: {utc_to_jst_str(self.updated_at)}"
     
     def get_as_obj(self):
         '''
         以下のような形で返す
         {
             'summary': 'ABC001',
-            'location': '',
-            'description': 'https://atcoder.jp/contests/abc001',
+            'location': 'https://atcoder.jp/contests/abc001',
+            'description': 'created at: 2021/08/20 23:00:11 JST\nupdated at: 2021/08/28 16:34:11 JST',
             'start': {
                 'dateTime': '2020-01-01T00:00:00',
                 'timeZone': 'Japan',
@@ -65,14 +71,19 @@ class CalendarEvent:
         '''
         return {
             'summary': self.summary,
-            'location': self.location,
-            'description': self.description,
+            'location': self.url,
+            'description': self.get_description(),
             'start': self.start.get_as_obj(),
             'end': self.end.get_as_obj()
         }
 
+def utc_to_jst_str(time: datetime.datetime) -> str:
+    """
+    takes utc datetime.datetime and return jst in str
+    """
+    return f"{(time + datetime.timedelta(hours=9)).strftime('%Y/%m/%d %H:%M:%S')} JST"
 
-def parse_event(name_obj, start_datetime_obj, duration_obj) -> CalendarEvent:
+def parse_text_obj_to_calendarevent(name_obj, start_datetime_obj, duration_obj, now: datetime.datetime) -> CalendarEvent:
     contest_title = name_obj.text
     contest_url = urlparse.urljoin(ATCODER_BASE_URL, name_obj.attrs['href'])
     start_at = dt.strptime(start_datetime_obj.text, '%Y-%m-%d %H:%M:%S+0900')
@@ -80,10 +91,10 @@ def parse_event(name_obj, start_datetime_obj, duration_obj) -> CalendarEvent:
     contest_duration = datetime.timedelta(hours=contest_hours, minutes=contest_minutes)
     end_at = start_at + contest_duration
     return CalendarEvent(
-        summary=contest_title, start_at=start_at, end_at=end_at, description=contest_url
+        summary=contest_title, url=contest_url, created_at=now, updated_at=now, start_at=start_at, end_at=end_at
     )
 
-def get_atcoder_schedule() -> List[CalendarEvent]:
+def get_atcoder_schedule(now: datetime.datetime) -> List[CalendarEvent]:
     res = requests.get(urlparse.urljoin(ATCODER_BASE_URL, "contests/?lang=ja"))
     res.raise_for_status()
     soup = bs4.BeautifulSoup(res.content, 'html.parser')
@@ -99,7 +110,7 @@ def get_atcoder_schedule() -> List[CalendarEvent]:
         sys.exit(1)
 
     event_list = [
-        parse_event(name_obj, start_datetime_obj, duration_obj)
+        parse_text_obj_to_calendarevent(name_obj, start_datetime_obj, duration_obj, now)
         for name_obj, start_datetime_obj, duration_obj in zip(name_objs, start_datetime_objs, duration_objs)
     ]
 
@@ -115,12 +126,21 @@ def add_updated_at(event: CalendarEvent, updated_at: datetime.datetime, create: 
         event.description += f"CREATED AT: {updated_at_str}\n"
     event.description += f"UPDATED AT: {updated_at_str}"
 
-def add_event(event: CalendarEvent, created_at: datetime.datetime):
-    add_updated_at(event, created_at, create=True)
+def add_event(event: CalendarEvent):
     added_event = API_SERVICE.events().insert(calendarId=CALENDAR_ID, body=event.get_as_obj()).execute()
 
-def get_registered_events(time_from: datetime.datetime, time_to: datetime.datetime):
-    registered_events = []
+def parse_event(event_item_obj) -> CalendarEvent:
+    return CalendarEvent(
+        summary=event_item_obj['summary'],
+        created_at=parser.parse(event_item_obj['created']),
+        updated_at=parser.parse(event_item_obj['updated']),
+        start_at=parser.parse(event_item_obj['start']['dateTime']),
+        end_at=parser.parse(event_item_obj['end']['dateTime']),
+        id=event_item_obj['id']
+    )
+
+def get_registered_events(time_from: datetime.datetime, time_to: datetime.datetime) -> List[CalendarEvent]:
+    registered_events: List[CalendarEvent] = []
     
     page_token = None
     while True:
@@ -130,7 +150,7 @@ def get_registered_events(time_from: datetime.datetime, time_to: datetime.dateti
             timeMax=f"{time_to.isoformat()}Z",
             pageToken=page_token
         ).execute()
-        registered_events += events['items']
+        registered_events += [parse_event(event_item_obj) for event_item_obj in events['items']]
         page_token = events.get('nextPageToken')
         if not page_token:
             break
@@ -146,27 +166,22 @@ def delete_events(time_from: datetime.datetime, time_to: datetime.datetime):
         ).execute()
     print(f'{len(events_to_delete)} events have been deleted.')
 
-def update_event(event_id: str, event_description: str, event: CalendarEvent, updated_at: datetime.datetime):
-    # Googleカレンダーの説明欄からCREATED ATを抜き出してeventにつける
-    description_lines = list(filter(lambda line: line != '', event_description.split('\n')))
-    # descriptionにURLとUPDATED ATしかつけてなかった時の名残のreplace
-    created_at_str = description_lines[1].replace('UPDATED AT: ', 'CREATED AT: ')
-    if event.description:
-        event.description += '\n'
-    event.description += created_at_str
+def update_event(registered_event: CalendarEvent, retrieved_event: CalendarEvent) -> None:
+    # created at: the time the registered event was created
+    retrieved_event.created_at = registered_event.created_at
+    # updated at: now
+    # retrieved_event.updated_at is already "now"
 
-    # 更新時間を更新
-    add_updated_at(event, updated_at)
     API_SERVICE.events().update(
         calendarId=CALENDAR_ID,
-        eventId=event_id,
-        body=event.get_as_obj()
+        eventId=registered_event.id,
+        body=retrieved_event.get_as_obj()
     ).execute()
 
 def main(data, context):
-    upcoming_contests = get_atcoder_schedule()
-    print(f"{len(upcoming_contests)} contests have been retrieved.")
     now = datetime.datetime.utcnow()
+    upcoming_contests = get_atcoder_schedule(now)
+    print(f"{len(upcoming_contests)} contests have been retrieved.")
     eight_week_later = now + datetime.timedelta(weeks=8)
 
     if not upcoming_contests:
@@ -180,9 +195,9 @@ def main(data, context):
     for uc in upcoming_contests:
         already_registered = False
         for rc in registered_contests:
-            if uc.summary == rc['summary']:
+            if uc.summary == rc.summary:
                 updated_count += 1
-                update_event(rc['id'], rc['description'], uc, now)
+                update_event(rc, uc)
                 already_registered = True
                 break
 
@@ -190,7 +205,7 @@ def main(data, context):
             continue
 
         inserted_count += 1
-        add_event(uc, now)
+        add_event(uc)
     
     print(f"{updated_count} contests have been updated.")
     print(f"{inserted_count} contests have been added.")


### PR DESCRIPTION
めっちゃ読みやすくなった気がする！？

1. クラスの構造変更
Googleカレンダーから取得した登録済みコンテストも、AtCoderからスクレイピングしたコンテスト情報も一回このクラスのインスタンスに変換される。
https://github.com/oirom/atcoder_calender/blob/7399570136dc36f9ee85003f60274cced4bf7a9d/main.py#L36-L78
Googleカレンダーのイベントとして、作成・更新されるときにインスタンスの `get_as_obj()` が呼ばれてGoogleカレンダーAPIに渡せる形になる。
概要欄に載る`created_at` と `updated_at` の更新方法も変更されている。Googleカレンダーのイベントも作成日時と更新日時を持っているので、使えるときはそれを使って概要欄を更新する。Googleカレンダーのイベントが持っている作成日時・更新日時は作成・更新のAPIを呼べばかってに変更されるので気にする必要があるのは概要欄の時間。
- イベント更新時
Googleカレンダーから取得した情報に、イベントの登録日時が含まれているのでそれを `created_at` として、`updated_at` にはプログラム内で生成した今の時間を適用する。
- イベント追加時
`created_at` 、 `updated_at` 両方ともプログラム内で生成した今の時間を適用する。

2. URLの表示位置変更
カレンダーの概要欄ではなく、「場所」のところにいれることにした。